### PR TITLE
Fix astral view initialization

### DIFF
--- a/testing2
+++ b/testing2
@@ -315,9 +315,15 @@
 
 <!-- ===== Script ===== -->
 <script>
+(() => {
   // --- State bootstrap ---
-  const storeKey = 'drsb-data-v2';
-  let state = load() || {};
+  const storeKey = window.storeKey || 'drsb-data-v2';
+  const save = window.save || function(){ localStorage.setItem(storeKey, JSON.stringify(state)); };
+  const load = window.load || function(){ try{ return JSON.parse(localStorage.getItem(storeKey)||''); }catch{return null} };
+  const uid = window.uid || function(){ return Math.random().toString(36).slice(2)+Date.now().toString(36); };
+  const qs = window.qs || (s=>document.querySelector(s));
+
+  let state = window.state || load() || {};
   state.portals = state.portals || [];
   state.waitingRooms = state.waitingRooms || [];
   state.journal = state.journal || [];
@@ -329,14 +335,15 @@
   // NEW: Astral
   state.astral = state.astral || { entries:[], goals:[], practices:[], sessions:[] };
   state.sync = state.sync || { provider:null, appKey:'', accessToken:'', path:'/Apps/DR Script Builder/data.json', auto:false, intervalMins:5, lastSync:0 };
-
-  function save(){ localStorage.setItem(storeKey, JSON.stringify(state)); }
-  function load(){ try{ return JSON.parse(localStorage.getItem(storeKey)||''); }catch{return null} }
-  function uid(){ return Math.random().toString(36).slice(2)+Date.now().toString(36); }
-  const qs = s=>document.querySelector(s);
+  window.state = state;
+  window.save = save;
+  window.load = load;
+  window.uid = uid;
+  window.qs = qs;
 
   // --- Views registry (only adding astral here; existing app should register its own elsewhere) ---
-  const views = { astral: qs('#astral-view') };
+  window.views = window.views || {};
+  window.views.astral = qs('#astral-view');
 
   // Hook up sidebar switching for this document instance
   document.querySelectorAll('.nav button').forEach(btn=>{
@@ -670,6 +677,7 @@
 
   // Initial render if user lands directly
   function renderAstral(){ renderApTags(); renderApJournal(); renderApGoals(); renderApPractices(); renderApSessions(); }
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Integrate Astral Projection view without overwriting global state or view registry
- Register Astral view via `window.views` and run in isolated IIFE to avoid collisions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c5cf08cd8832a8dbc662dabc54635